### PR TITLE
K/quests.md

### DIFF
--- a/website/docs/code/datapack/format/quests.md
+++ b/website/docs/code/datapack/format/quests.md
@@ -1,6 +1,7 @@
 # Quest Data
 Quests are tasks the player can take that have goals that must be met and rewards that they provide. A quest can be a specific set of goals and rewards, or can have randomisation in what is required or rewarded.
 
+
 ## Location
 `data/wotr/wotr/quest` Take note of the second wotr.
 

--- a/website/docs/code/datapack/format/quests.md
+++ b/website/docs/code/datapack/format/quests.md
@@ -1,24 +1,6 @@
 # Quest Data
 Quests are tasks the player can take that have goals that must be met and rewards that they provide. A quest can be a specific set of goals and rewards, or can have randomisation in what is required or rewarded.
 
-<!-- TOC -->
-* [Quest Data](#quest-data)
-  * [Location](#location)
-  * [Format](#format)
-  * [Localisation](#localisation)
-  * [Goals](#goals)
-    * [Give Item](#give-item)
-    * [Fixed Give Item](#fixed-give-item)
-    * [Complete Rift](#complete-rift)
-    * [Fixed Complete Rift](#fixed-complete-rift)
-    * [Fixed Kill Mob](#fixed-kill-mob)
-    * [Pool](#pool)
-  * [Rewards](#rewards)
-    * [Item Reward](#item-reward)
-    * [Loot Table Reward](#loot-table-reward)
-  * [Overall Example](#overall-example)
-<!-- TOC -->
-
 ## Location
 `data/wotr/wotr/quest` Take note of the second wotr.
 


### PR DESCRIPTION
Docusaurus already create navigation based on headers.
As there were reports of non-functional anchor links in this doc the simplest 'fix' is to remove this section and just default to the automatically generated navigation.